### PR TITLE
feat: Add initial Android CI workflow

### DIFF
--- a/.github/workflow/ci.yml
+++ b/.github/workflow/ci.yml
@@ -1,0 +1,25 @@
+name : Android CI
+
+on:
+  push:
+    branches: [ "feature/rick_and_morty" ]
+  pull_request:
+    branches: [ "feature/rick_and_morty" ]
+
+  jobs:
+    build:
+      runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: gradle
+      - name: Setup Gradle
+        uses: gradle/gradle-build-actions@v2
+      - name: Build app
+        run: ./gradlew assemble
+


### PR DESCRIPTION
Adds a new GitHub Actions workflow for Android CI.

This workflow runs on push and pull_request events to the `feature/rick_and_morty` branch. It checks out the code, sets up JDK 11, and runs the `./gradlew assemble` command to build the app.